### PR TITLE
identificar contenedor en HealthMonitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,5 +58,6 @@ En la terminal de KubeVigilant deberías ver inmediatamente:
 🚨 DETECCIÓN DE FALLO CRÍTICO
    📦 Pod: pod-suicida
    🏷️  NS:  default
+   📦 Contenedor: nombre-del-contenedor
    💥 Estado: CrashLoopBackOff
 ```


### PR DESCRIPTION
  refs: #2

- cuando un pod falla, recuperar el objeto de estado y mostrar el nombre del contenedor en el reportCrash
- ajustar README por consistencia